### PR TITLE
Implement label matching logic in metric declarations

### DIFF
--- a/exporter/awsemfexporter/README.md
+++ b/exporter/awsemfexporter/README.md
@@ -35,7 +35,7 @@ A metric_declaration section characterizes a rule to be used to set dimensions f
 | `metric_name_selectors` | List of regex strings to filter metric names by.                 |         |
 | [`label_matchers`](#label_matcher)  | (Optional) list of label matching rules to filter metrics by their labels. This rule is applied to any metric that matches any of the label matchers. |   [ ]    |
 
-### <label_matcher>
+#### <label_matcher>
 A label_matcher section defines a matching rule against the labels of the incoming metric. Only metrics that match the rules will be used by the surrounding `metric_declaration`.
 | Name              | Description                                                            | Default |
 | :---------------- | :--------------------------------------------------------------------- | ------- |

--- a/exporter/awsemfexporter/README.md
+++ b/exporter/awsemfexporter/README.md
@@ -28,11 +28,20 @@ The following exporter configuration parameters are supported.
 | [`metric_declarations`](#metric_declaration) | List of rules for filtering exported metrics and their dimensions. |    [ ]   |
 
 ### <metric_declaration>
-A metric_declaration section characterizes a rule to be used to set dimensions for exported metrics, filtered by the incoming metrics' metric names.
+A metric_declaration section characterizes a rule to be used to set dimensions for exported metrics, filtered by the incoming metrics' labels and metric names.
 | Name              | Description                                                            | Default |
 | :---------------- | :--------------------------------------------------------------------- | ------- |
 | `dimensions`      | List of dimension sets to be exported.                                 |  [[ ]]   |
 | `metric_name_selectors` | List of regex strings to filter metric names by.                 |   [ ]    |
+| [`label_matchers`](#label_matcher)  | (Optional) list of label matching rules to filter metrics by their labels. This rule is applied to any metric that matches any of the label matchers. |   [ ]    |
+
+### <label_matcher>
+A label_matcher section defines a matching rule against the labels of the incoming metric. Only metrics that match the rules will be used by the surrounding `metric_declaration`.
+| Name              | Description                                                            | Default |
+| :---------------- | :--------------------------------------------------------------------- | ------- |
+| `label_names`     | List of label names to filter by. Their corresponding values are concatenated using the separator and matched against the configured regular expression.                             |   [ ]    |
+| `separator`       | (Optional) separator placed between concatenated label values.         |   ";"   |
+| `regex`           | (Optional) regex string to be matched against concatenated label values. |  ".+"  |
 
 
 ## AWS Credential Configuration

--- a/exporter/awsemfexporter/README.md
+++ b/exporter/awsemfexporter/README.md
@@ -32,16 +32,16 @@ A metric_declaration section characterizes a rule to be used to set dimensions f
 | Name              | Description                                                            | Default |
 | :---------------- | :--------------------------------------------------------------------- | ------- |
 | `dimensions`      | List of dimension sets to be exported.                                 |  [[ ]]   |
-| `metric_name_selectors` | List of regex strings to filter metric names by.                 |   [ ]    |
+| `metric_name_selectors` | List of regex strings to filter metric names by.                 |         |
 | [`label_matchers`](#label_matcher)  | (Optional) list of label matching rules to filter metrics by their labels. This rule is applied to any metric that matches any of the label matchers. |   [ ]    |
 
 ### <label_matcher>
 A label_matcher section defines a matching rule against the labels of the incoming metric. Only metrics that match the rules will be used by the surrounding `metric_declaration`.
 | Name              | Description                                                            | Default |
 | :---------------- | :--------------------------------------------------------------------- | ------- |
-| `label_names`     | List of label names to filter by. Their corresponding values are concatenated using the separator and matched against the configured regular expression.                             |   [ ]    |
+| `label_names`     | List of label names to filter by. Their corresponding values are concatenated using the separator and matched against the configured regular expression.                             |         |
 | `separator`       | (Optional) separator placed between concatenated label values.         |   ";"   |
-| `regex`           | (Optional) regex string to be matched against concatenated label values. |  ".+"  |
+| `regex`           | Regex string to be matched against concatenated label values.          |         |
 
 
 ## AWS Credential Configuration

--- a/exporter/awsemfexporter/metric_declaration.go
+++ b/exporter/awsemfexporter/metric_declaration.go
@@ -51,8 +51,7 @@ type LabelMatcher struct {
 	LabelNames []string `mapstructure:"label_names"`
 	// (Optional) Separator placed between concatenated source label values. (Default: ';')
 	Separator string `mapstructure:"separator"`
-	// (Optional) Regex string to be used to match against values of the concatenated
-	// labels. (Default: '.+)
+	// Regex string to be used to match against values of the concatenated labels.
 	Regex string `mapstructure:"regex"`
 
 	compiledRegex *regexp.Regexp
@@ -182,11 +181,11 @@ func (lm *LabelMatcher) Init() (err error) {
 	if len(lm.LabelNames) == 0 {
 		return errors.New("label matcher must have at least one label name specified")
 	}
+	if len(lm.Regex) == 0 {
+		return errors.New("regex not specified for label matcher")
+	}
 	if len(lm.Separator) == 0 {
 		lm.Separator = ";"
-	}
-	if len(lm.Regex) == 0 {
-		lm.Regex = ".+"
 	}
 	lm.compiledRegex = regexp.MustCompile(lm.Regex)
 	return

--- a/exporter/awsemfexporter/metric_declaration.go
+++ b/exporter/awsemfexporter/metric_declaration.go
@@ -99,7 +99,7 @@ func (m *MetricDeclaration) Init(logger *zap.Logger) (err error) {
 		// Dedup dimensions within dimension set
 		dedupedDims, hasDuplicate := dedupDimensionSet(dimSet)
 		if hasDuplicate {
-			logger.Warn("Removed duplicates from dimension set.", zap.String("dimensions", concatenatedDims))
+			logger.Debug("Removed duplicates from dimension set.", zap.String("dimensions", concatenatedDims))
 		}
 
 		// Sort dimensions
@@ -108,7 +108,7 @@ func (m *MetricDeclaration) Init(logger *zap.Logger) (err error) {
 		// Dedup dimension sets
 		key := strings.Join(dedupedDims, ",")
 		if _, ok := seen[key]; ok {
-			logger.Warn("Dropped dimension set: duplicated dimension set.", zap.String("dimensions", concatenatedDims))
+			logger.Debug("Dropped dimension set: duplicated dimension set.", zap.String("dimensions", concatenatedDims))
 			continue
 		}
 		seen[key] = true
@@ -180,7 +180,7 @@ func (m *MetricDeclaration) ExtractDimensions(labels map[string]string) (dimensi
 func (lm *LabelMatcher) Init() (err error) {
 	// Throw error if no label names are specified
 	if len(lm.LabelNames) == 0 {
-		return errors.New("Label matcher must have at least one label name specified.")
+		return errors.New("label matcher must have at least one label name specified")
 	}
 	if len(lm.Separator) == 0 {
 		lm.Separator = ";"

--- a/exporter/awsemfexporter/metric_declaration.go
+++ b/exporter/awsemfexporter/metric_declaration.go
@@ -198,7 +198,7 @@ func (lm *LabelMatcher) Matches(labels map[string]string) bool {
 	return lm.compiledRegex.MatchString(concatenatedLabels)
 }
 
-// Concatenate matched labels using separator defined by the LabelMatcher's rules.
+// Concatenate label values of matched labels using separator defined by the LabelMatcher's rules.
 func (lm *LabelMatcher) getConcatenatedLabels(labels map[string]string) string {
 	buf := new(bytes.Buffer)
 	isFirstLabel := true

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -54,7 +54,7 @@ func TestLabelMatcherInit(t *testing.T) {
 	lm.LabelNames = []string{}
 	err = lm.Init()
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "Label matcher must have at least one label name specified.")
+	assert.EqualError(t, err, "label matcher must have at least one label name specified")
 }
 
 func TestGetConcatenatedLabels(t *testing.T) {
@@ -277,7 +277,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			},
 			MetricNameSelectors: []string{"a.*", "b$", "aa+"},
 		}
-		obs, logs := observer.New(zap.WarnLevel)
+		obs, logs := observer.New(zap.DebugLevel)
 		obsLogger := zap.New(obs)
 		err := m.Init(obsLogger)
 		assert.Nil(t, err)
@@ -286,11 +286,11 @@ func TestMetricDeclarationInit(t *testing.T) {
 		// Check logged warning message
 		expectedLogs := []observer.LoggedEntry{
 			{
-				Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Removed duplicates from dimension set."},
+				Entry:   zapcore.Entry{Level: zap.DebugLevel, Message: "Removed duplicates from dimension set."},
 				Context: []zapcore.Field{zap.String("dimensions", "a,c,b,c")},
 			},
 			{
-				Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Dropped dimension set: duplicated dimension set."},
+				Entry:   zapcore.Entry{Level: zap.DebugLevel, Message: "Dropped dimension set: duplicated dimension set."},
 				Context: []zapcore.Field{zap.String("dimensions", "c,b,a")},
 			},
 		}
@@ -347,7 +347,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		}
 		err := m.Init(logger)
 		assert.NotNil(t, err)
-		assert.EqualError(t, err, "Label matcher must have at least one label name specified.")
+		assert.EqualError(t, err, "label matcher must have at least one label name specified")
 	})
 }
 

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -27,6 +27,7 @@ import (
 func TestLabelMatcherInit(t *testing.T) {
 	lm := &LabelMatcher{
 		LabelNames: []string{"label1", "label2"},
+		Regex: ".+",
 	}
 	err := lm.Init()
 	assert.Nil(t, err)
@@ -51,7 +52,13 @@ func TestLabelMatcherInit(t *testing.T) {
 	assert.NotNil(t, lm.compiledRegex)
 
 	// Test error
+	lm.Regex = ""
+	err = lm.Init()
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "regex not specified for label matcher")
+
 	lm.LabelNames = []string{}
+	lm.Regex = ".+"
 	err = lm.Init()
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "label matcher must have at least one label name specified")
@@ -105,6 +112,7 @@ func TestGetConcatenatedLabels(t *testing.T) {
 		lm := &LabelMatcher{
 			LabelNames: tc.labelNames,
 			Separator:  tc.separator,
+			Regex: ".+",
 		}
 		lm.Init()
 		t.Run(tc.testName, func(t *testing.T) {
@@ -150,6 +158,7 @@ func TestLabelMatcherMatches(t *testing.T) {
 			},
 			&LabelMatcher{
 				LabelNames: []string{"label2"},
+				Regex: ".+",
 			},
 			false,
 		},
@@ -313,6 +322,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			LabelMatchers: []*LabelMatcher{
 				{
 					LabelNames: []string{"label1", "label2"},
+					Regex: ".+",
 				},
 				{
 					LabelNames: []string{"label1", "label3"},
@@ -339,15 +349,29 @@ func TestMetricDeclarationInit(t *testing.T) {
 			LabelMatchers: []*LabelMatcher{
 				{
 					LabelNames: []string{"label1", "label2"},
+					Regex: ".+",
 				},
 				{
 					LabelNames: []string{},
+					Regex: ".+",
 				},
 			},
 		}
 		err := m.Init(logger)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "label matcher must have at least one label name specified")
+
+		m = &MetricDeclaration{
+			MetricNameSelectors: []string{"foo"},
+			LabelMatchers: []*LabelMatcher{
+				{
+					LabelNames: []string{"label1", "label2"},
+				},
+			},
+		}
+		err = m.Init(logger)
+		assert.NotNil(t, err)
+		assert.EqualError(t, err, "regex not specified for label matcher")
 	})
 }
 

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -27,7 +27,7 @@ import (
 func TestLabelMatcherInit(t *testing.T) {
 	lm := &LabelMatcher{
 		LabelNames: []string{"label1", "label2"},
-		Regex: ".+",
+		Regex:      ".+",
 	}
 	err := lm.Init()
 	assert.Nil(t, err)
@@ -112,7 +112,7 @@ func TestGetConcatenatedLabels(t *testing.T) {
 		lm := &LabelMatcher{
 			LabelNames: tc.labelNames,
 			Separator:  tc.separator,
-			Regex: ".+",
+			Regex:      ".+",
 		}
 		lm.Init()
 		t.Run(tc.testName, func(t *testing.T) {
@@ -158,7 +158,7 @@ func TestLabelMatcherMatches(t *testing.T) {
 			},
 			&LabelMatcher{
 				LabelNames: []string{"label2"},
-				Regex: ".+",
+				Regex:      ".+",
 			},
 			false,
 		},
@@ -322,7 +322,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			LabelMatchers: []*LabelMatcher{
 				{
 					LabelNames: []string{"label1", "label2"},
-					Regex: ".+",
+					Regex:      ".+",
 				},
 				{
 					LabelNames: []string{"label1", "label3"},
@@ -349,11 +349,11 @@ func TestMetricDeclarationInit(t *testing.T) {
 			LabelMatchers: []*LabelMatcher{
 				{
 					LabelNames: []string{"label1", "label2"},
-					Regex: ".+",
+					Regex:      ".+",
 				},
 				{
 					LabelNames: []string{},
-					Regex: ".+",
+					Regex:      ".+",
 				},
 			},
 		}

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -182,7 +182,7 @@ func TranslateCWMetricToEMF(cwMetricLists []*CWMetrics, logger *zap.Logger) []*L
 			fieldMap["_aws"] = cwmMap
 		} else {
 			str, _ := json.Marshal(fieldMap)
-			logger.Warn("Dropped metric due to no matching metric declarations", zap.String("labels", string(str)))
+			logger.Debug("Dropped metric due to no matching metric declarations", zap.String("labels", string(str)))
 		}
 
 		pleMsg, err := json.Marshal(fieldMap)

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -690,7 +690,7 @@ func TestTranslateCWMetricToEMFNoMeasurements(t *testing.T) {
 		Fields:       fields,
 		Measurements: nil,
 	}
-	obs, logs := observer.New(zap.WarnLevel)
+	obs, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(obs)
 	inputLogEvent := TranslateCWMetricToEMF([]*CWMetrics{met}, logger)
 	expected := "{\"OTelLib\":\"cloudwatch-otel\",\"spanCounter\":0,\"spanName\":\"test\"}"
@@ -700,7 +700,7 @@ func TestTranslateCWMetricToEMFNoMeasurements(t *testing.T) {
 	// Check logged warning message
 	fieldsStr, _ := json.Marshal(fields)
 	expectedLogs := []observer.LoggedEntry{{
-		Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Dropped metric due to no matching metric declarations"},
+		Entry:   zapcore.Entry{Level: zap.DebugLevel, Message: "Dropped metric due to no matching metric declarations"},
 		Context: []zapcore.Field{zap.String("labels", string(fieldsStr))},
 	}}
 	assert.Equal(t, 1, logs.Len())


### PR DESCRIPTION
**Description:**
This PR extends the features implemented in #2 for `MetricDeclarations` by adding functionality for filtering metrics by labels using regex. This filtering logic works similarly to how it's done in [Prometheus' `relabel_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config).

Specifically, we include a new optional `label_matchers` attribute under `metric_declarations` that defines a list of label matching rules. The surrounding metric declaration rule is applied to a given metric if the metric's labels matches any one of the label matching rules. The API for each label matcher is:

```yaml
# List of label names to filter by. Their corresponding values are
# concatenated using the configured separator and matched against the configured
# regular expression.
label_names: [ - <string> ]

# (Optional) Separator placed between concatenated source label values.
separator: <string> | default = ';'

# Regex string to be used to match against values of the source labels defined in `source_labels`. 
regex: <string>
```

**Testing:** 
This code change was tested using new unit tests also included in this PR. This change was also tested on CW logs using a sample NGINX Prometheus workload. Given the following config:
```yaml
exporters:
  awsemf:
    log_group_name: 'awscollector-test'
    region: 'us-west-2'
    log_stream_name: metric-declarations
    dimension_rollup_option: 'NoDimensionRollup'
    metric_declarations:
    - dimensions: [['Service', 'Namespace'], ['pod_name', 'container_name']]
      metric_name_selectors:
      - '^go_memstats_alloc_bytes_total$'
      label_matchers:
      - label_names: ['app_kubernetes_io_name', 'app_kubernetes_io_instance']
        regex: '^ingress-nginx;my-nginx$'
```

The corresponding exported metrics for `go_memstats_alloc_bytes_total` were:
```json
{
    "Namespace": "eks-aoc",
    "Service": "my-nginx-ingress-nginx-controller-metrics",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "kubernetes-service-endpoints",
                "Dimensions": [
                    [
                        "Namespace",
                        "Service"
                    ],
                    [
                        "container_name",
                        "pod_name"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "go_memstats_alloc_bytes_total",
                        "Unit": ""
                    }
                ]
            }
        ],
        "Timestamp": 1605297772208
    },
    "app_kubernetes_io_component": "controller",
    "app_kubernetes_io_instance": "my-nginx",
    "app_kubernetes_io_managed_by": "Helm",
    "app_kubernetes_io_name": "ingress-nginx",
    "app_kubernetes_io_version": "0.40.2",
    "container_name": "controller",
    "go_memstats_alloc_bytes_total": 0,
    "helm_sh_chart": "ingress-nginx-3.7.1",
    "kubernetes_node": "ip-192-168-69-5.us-west-2.compute.internal",
    "pod_name": "my-nginx-ingress-nginx-controller-77d5fd6977-4zprn"
}
```
and 
```json
{
    "Namespace": "kube-system",
    "Service": "kube-dns",
    "container_name": "coredns",
    "eks_amazonaws_com_component": "kube-dns",
    "go_memstats_alloc_bytes_total": 0,
    "k8s_app": "kube-dns",
    "kubernetes_io_cluster_service": "true",
    "kubernetes_io_name": "CoreDNS",
    "kubernetes_node": "ip-192-168-1-121.us-west-2.compute.internal",
    "pod_name": "coredns-5946c5d67c-zndg7"
}
```

Note that the second log had no metrics exported because it didn't have the right labels.

**Documentation:**
The documentation in the README for the awsemfexporter is also updated to include this new API change.