### PR TITLE
Implement dimension dedup logic when adding rolledup dimensions

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -291,9 +292,7 @@ func buildCWMetric(dp DataPoint, pmd *pdata.Metric, namespace string, metricSlic
 	// Build list of CW Measurements
 	cwMeasurements := make([]CwMeasurement, len(dimensionsArray))
 	for i, dimensions := range dimensionsArray {
-		if len(rollupDimensionArray) > 0 {
-			dimensions = append(dimensions, rollupDimensionArray...)
-		}
+		dimensions = dedupDimensions(dimensions, rollupDimensionArray)
 		cwMeasurements[i] = CwMeasurement{
 			Namespace:  namespace,
 			Dimensions: dimensions,
@@ -413,14 +412,38 @@ func dimensionRollup(dimensionRollupOption string, originalDimensionSlice []stri
 	}
 	if dimensionRollupOption == ZeroAndSingleDimensionRollup || dimensionRollupOption == SingleDimensionRollupOnly {
 		//"One" dimension rollup
-		if len(originalDimensionSlice) > 1 {
-			for _, dimensionKey := range originalDimensionSlice {
-				rollupDimensionArray = append(rollupDimensionArray, append(dimensionZero, dimensionKey))
-			}
+		for _, dimensionKey := range originalDimensionSlice {
+			rollupDimensionArray = append(rollupDimensionArray, append(dimensionZero, dimensionKey))
 		}
 	}
 
 	return rollupDimensionArray
+}
+
+// dedupDimensions appends rolled-up dimensions to existing dimensions and removes duplicate dimension sets.
+func dedupDimensions(dimensions, rolledUpDims [][]string) [][]string {
+	deduped := make([][]string, len(dimensions)+len(rolledUpDims))
+	seen := make(map[string]bool, len(deduped))
+	idx := 0
+
+	addDeduped := func(dimSet []string) {
+		sort.Strings(dimSet)
+		key := strings.Join(dimSet, ",")
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = true
+		deduped[idx] = dimSet
+		idx++
+	}
+
+	for _, dimSet := range dimensions {
+		addDeduped(dimSet)
+	}
+	for _, dimSet := range rolledUpDims {
+		addDeduped(dimSet)
+	}
+	return deduped[:idx]
 }
 
 func needsCalculateRate(pmd *pdata.Metric) bool {

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -338,14 +338,14 @@ func TestTranslateOtToCWMetricWithFiltering(t *testing.T) {
 	logger := zap.NewNop()
 
 	for _, tc := range testCases {
-		md := MetricDeclaration{
+		m := MetricDeclaration{
 			Dimensions:          [][]string{{"isItAnError", "spanName"}},
 			MetricNameSelectors: tc.metricNameSelectors,
 		}
 		config := &Config{
 			Namespace:             "",
 			DimensionRollupOption: ZeroAndSingleDimensionRollup,
-			MetricDeclarations:    []*MetricDeclaration{&md},
+			MetricDeclarations:    []*MetricDeclaration{&m},
 		}
 		t.Run(tc.testName, func(t *testing.T) {
 			err := m.Init(logger)

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -56,9 +56,16 @@ func assertDimsEqual(t *testing.T, expected, actual [][]string) {
 	assert.Equal(t, expectedStringified, actualStringified)
 }
 
+// Asserts whether CW Measurements are equal.
+func assertCwMeasurementEqual(t *testing.T, expected, actual CwMeasurement) {
+	assert.Equal(t, expected.Namespace, actual.Namespace)
+	assert.Equal(t, expected.Metrics, actual.Metrics)
+	assertDimsEqual(t, expected.Dimensions, actual.Dimensions)
+}
+
 func TestTranslateOtToCWMetricWithInstrLibrary(t *testing.T) {
 	config := &Config{
-		Namespace: "",
+		Namespace:             "",
 		DimensionRollupOption: ZeroAndSingleDimensionRollup,
 	}
 	md := createMetricTestData()
@@ -99,7 +106,7 @@ func TestTranslateOtToCWMetricWithInstrLibrary(t *testing.T) {
 
 func TestTranslateOtToCWMetricWithoutInstrLibrary(t *testing.T) {
 	config := &Config{
-		Namespace: "",
+		Namespace:             "",
 		DimensionRollupOption: ZeroAndSingleDimensionRollup,
 	}
 	md := createMetricTestData()
@@ -138,7 +145,7 @@ func TestTranslateOtToCWMetricWithoutInstrLibrary(t *testing.T) {
 
 func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {
 	config := &Config{
-		Namespace: "",
+		Namespace:             "",
 		DimensionRollupOption: ZeroAndSingleDimensionRollup,
 	}
 	md := consumerdata.MetricsData{
@@ -307,8 +314,8 @@ func TestTranslateOtToCWMetricWithFiltering(t *testing.T) {
 	testCases := []struct {
 		testName            string
 		metricNameSelectors []string
-		dimensions       	[][]string
-		numMeasurements		int
+		dimensions          [][]string
+		numMeasurements     int
 	}{
 		{
 			"With match",
@@ -331,14 +338,14 @@ func TestTranslateOtToCWMetricWithFiltering(t *testing.T) {
 	logger := zap.NewNop()
 
 	for _, tc := range testCases {
-		m := MetricDeclaration{
-			Dimensions: [][]string{{"isItAnError", "spanName"}},
+		md := MetricDeclaration{
+			Dimensions:          [][]string{{"isItAnError", "spanName"}},
 			MetricNameSelectors: tc.metricNameSelectors,
 		}
 		config := &Config{
-			Namespace: "",
+			Namespace:             "",
 			DimensionRollupOption: ZeroAndSingleDimensionRollup,
-			MetricDeclarations: []*MetricDeclaration{&m},
+			MetricDeclarations:    []*MetricDeclaration{&md},
 		}
 		t.Run(tc.testName, func(t *testing.T) {
 			err := m.Init(logger)
@@ -418,7 +425,7 @@ func TestGetCWMetrics(t *testing.T) {
 	OTelLib := "OTelLib"
 	instrumentationLibName := "InstrLibName"
 	config := &Config{
-		Namespace: "",
+		Namespace:             "",
 		DimensionRollupOption: "",
 	}
 
@@ -914,7 +921,9 @@ func TestGetCWMetrics(t *testing.T) {
 			for i, expected := range tc.expected {
 				cwMetric := cwMetrics[i]
 				assert.Equal(t, len(expected.Measurements), len(cwMetric.Measurements))
-				assert.Equal(t, expected.Measurements, cwMetric.Measurements)
+				for i, expectedMeasurement := range expected.Measurements {
+					assertCwMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[i])
+				}
 				assert.Equal(t, len(expected.Fields), len(cwMetric.Fields))
 				assert.Equal(t, expected.Fields, cwMetric.Fields)
 			}
@@ -933,7 +942,7 @@ func TestBuildCWMetric(t *testing.T) {
 		},
 	}
 	config := &Config{
-		Namespace: "",
+		Namespace:             "",
 		DimensionRollupOption: "",
 	}
 
@@ -960,7 +969,7 @@ func TestBuildCWMetric(t *testing.T) {
 			Dimensions: [][]string{{"label1", OTelLib}},
 			Metrics:    metricSlice,
 		}
-		assert.Equal(t, expectedMeasurement, cwMetric.Measurements[0])
+		assertCwMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
 		expectedFields := map[string]interface{}{
 			OTelLib:  instrLibName,
 			"foo":    int64(-17),
@@ -987,7 +996,7 @@ func TestBuildCWMetric(t *testing.T) {
 			Dimensions: [][]string{{"label1", OTelLib}},
 			Metrics:    metricSlice,
 		}
-		assert.Equal(t, expectedMeasurement, cwMetric.Measurements[0])
+		assertCwMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
 		expectedFields := map[string]interface{}{
 			OTelLib:  instrLibName,
 			"foo":    0.3,
@@ -1016,7 +1025,7 @@ func TestBuildCWMetric(t *testing.T) {
 			Dimensions: [][]string{{"label1", OTelLib}},
 			Metrics:    metricSlice,
 		}
-		assert.Equal(t, expectedMeasurement, cwMetric.Measurements[0])
+		assertCwMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
 		expectedFields := map[string]interface{}{
 			OTelLib:  instrLibName,
 			"foo":    0,
@@ -1045,7 +1054,7 @@ func TestBuildCWMetric(t *testing.T) {
 			Dimensions: [][]string{{"label1", OTelLib}},
 			Metrics:    metricSlice,
 		}
-		assert.Equal(t, expectedMeasurement, cwMetric.Measurements[0])
+		assertCwMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
 		expectedFields := map[string]interface{}{
 			OTelLib:  instrLibName,
 			"foo":    0,
@@ -1075,7 +1084,7 @@ func TestBuildCWMetric(t *testing.T) {
 			Dimensions: [][]string{{"label1", OTelLib}},
 			Metrics:    metricSlice,
 		}
-		assert.Equal(t, expectedMeasurement, cwMetric.Measurements[0])
+		assertCwMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
 		expectedFields := map[string]interface{}{
 			OTelLib: instrLibName,
 			"foo": &CWMetricStats{
@@ -1088,7 +1097,7 @@ func TestBuildCWMetric(t *testing.T) {
 		}
 		assert.Equal(t, expectedFields, cwMetric.Fields)
 	})
-	
+
 	t.Run("Invalid datapoint type", func(t *testing.T) {
 		metric.SetDataType(pdata.MetricDataTypeIntGauge)
 		dp := pdata.NewIntHistogramDataPoint()
@@ -1100,10 +1109,10 @@ func TestBuildCWMetric(t *testing.T) {
 
 	// Test rollup options and labels
 	testCases := []struct {
-		testName 				string
-		labels 					map[string]string
-		dimensionRollupOption 	string
-		expectedDims 			[][]string
+		testName              string
+		labels                map[string]string
+		dimensionRollupOption string
+		expectedDims          [][]string
 	}{
 		{
 			"Single label w/ no rollup",
@@ -1167,29 +1176,31 @@ func TestBuildCWMetric(t *testing.T) {
 			dp.LabelsMap().InitFromMap(tc.labels)
 			dp.SetValue(int64(-17))
 			config = &Config{
-				Namespace: namespace,
+				Namespace:             namespace,
 				DimensionRollupOption: tc.dimensionRollupOption,
 			}
 
 			expectedFields := map[string]interface{}{
 				OTellibDimensionKey: OTelLib,
-				"foo": int64(-17),
+				"foo":               int64(-17),
 			}
 			for k, v := range tc.labels {
 				expectedFields[k] = v
 			}
+			expectedMeasurement := CwMeasurement{
+				Namespace:  namespace,
+				Dimensions: tc.expectedDims,
+				Metrics:    metricSlice,
+			}
 
 			cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, OTelLib, config)
-			
+
 			// Check fields
 			assert.Equal(t, expectedFields, cwMetric.Fields)
 
 			// Check CW measurement
 			assert.Equal(t, 1, len(cwMetric.Measurements))
-			cwMeasurement := cwMetric.Measurements[0]
-			assert.Equal(t, namespace, cwMeasurement.Namespace)
-			assert.Equal(t, metricSlice, cwMeasurement.Metrics)
-			assertDimsEqual(t, tc.expectedDims, cwMeasurement.Dimensions)
+			assertCwMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
 		})
 	}
 }
@@ -1204,18 +1215,18 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 	metric.SetName(metricName)
 	metricSlice := []map[string]string{{"Name": metricName}}
 	testCases := []struct {
-		testName 				string
-		labels 					map[string]string
-		metricDeclarations 		[]*MetricDeclaration
-		dimensionRollupOption 	string
-		expectedDims 			[][][]string
+		testName              string
+		labels                map[string]string
+		metricDeclarations    []*MetricDeclaration
+		dimensionRollupOption string
+		expectedDims          [][][]string
 	}{
 		{
 			"Single label w/ no rollup",
 			map[string]string{"a": "foo"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a"}},
+					Dimensions:          [][]string{{"a"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1227,7 +1238,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", OTelLib}},
+					Dimensions:          [][]string{{"a", OTelLib}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1239,7 +1250,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a"}},
+					Dimensions:          [][]string{{"a"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1251,7 +1262,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a"}},
+					Dimensions:          [][]string{{"a"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1263,7 +1274,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a"}},
+					Dimensions:          [][]string{{"a"}},
 					MetricNameSelectors: []string{"invalid"},
 				},
 			},
@@ -1275,7 +1286,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a"}},
+					Dimensions:          [][]string{{"a"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1287,7 +1298,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a"}},
+					Dimensions:          [][]string{{"a"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1304,7 +1315,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					Dimensions:          [][]string{{"a", "b"}, {"b"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1316,7 +1327,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b"}, {"b", OTelLib}, {OTelLib}},
+					Dimensions:          [][]string{{"a", "b"}, {"b", OTelLib}, {OTelLib}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1328,7 +1339,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					Dimensions:          [][]string{{"a", "b"}, {"b"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1346,7 +1357,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b", "c"}, {"b"}},
+					Dimensions:          [][]string{{"a", "b", "c"}, {"b"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1363,7 +1374,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar", "c": "car"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					Dimensions:          [][]string{{"a", "b"}, {"b"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1382,15 +1393,15 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar", "c": "car"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					Dimensions:          [][]string{{"a", "b"}, {"b"}},
 					MetricNameSelectors: []string{metricName},
 				},
 				{
-					Dimensions: [][]string{{"a", "c"}, {"b"}, {"c"}},
+					Dimensions:          [][]string{{"a", "c"}, {"b"}, {"c"}},
 					MetricNameSelectors: []string{metricName},
 				},
 				{
-					Dimensions: [][]string{{"a", "d"}, {"b", "c"}},
+					Dimensions:          [][]string{{"a", "d"}, {"b", "c"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1406,15 +1417,15 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar", "c": "car"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					Dimensions:          [][]string{{"a", "b"}, {"b"}},
 					MetricNameSelectors: []string{metricName},
 				},
 				{
-					Dimensions: [][]string{{"a", "c"}, {"b"}, {"c"}},
+					Dimensions:          [][]string{{"a", "c"}, {"b"}, {"c"}},
 					MetricNameSelectors: []string{metricName},
 				},
 				{
-					Dimensions: [][]string{{"a", "d"}, {"b", "c"}},
+					Dimensions:          [][]string{{"a", "d"}, {"b", "c"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1451,11 +1462,11 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar", "c": "car"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					Dimensions:          [][]string{{"a", "b"}, {"b"}},
 					MetricNameSelectors: []string{metricName},
 				},
 				{
-					Dimensions: [][]string{{"a", "d"}},
+					Dimensions:          [][]string{{"a", "d"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1469,11 +1480,11 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{"a": "foo", "b": "bar", "c": "car"},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "e"}, {"d"}},
+					Dimensions:          [][]string{{"a", "e"}, {"d"}},
 					MetricNameSelectors: []string{metricName},
 				},
 				{
-					Dimensions: [][]string{{"a", "d"}},
+					Dimensions:          [][]string{{"a", "d"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1485,7 +1496,7 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			map[string]string{},
 			[]*MetricDeclaration{
 				{
-					Dimensions: [][]string{{"a", "b", "c"}, {"b"}},
+					Dimensions:          [][]string{{"a", "b", "c"}, {"b"}},
 					MetricNameSelectors: []string{metricName},
 				},
 			},
@@ -1501,9 +1512,9 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 			dp.LabelsMap().InitFromMap(tc.labels)
 			dp.SetValue(metricValue)
 			config := &Config{
-				Namespace: namespace,
+				Namespace:             namespace,
 				DimensionRollupOption: tc.dimensionRollupOption,
-				MetricDeclarations: tc.metricDeclarations,
+				MetricDeclarations:    tc.metricDeclarations,
 			}
 			logger := zap.NewNop()
 			for _, m := range tc.metricDeclarations {
@@ -1513,24 +1524,26 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 
 			expectedFields := map[string]interface{}{
 				OTellibDimensionKey: OTelLib,
-				metricName: metricValue,
+				metricName:          metricValue,
 			}
 			for k, v := range tc.labels {
 				expectedFields[k] = v
 			}
 
 			cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, OTelLib, config)
-			
+
 			// Check fields
 			assert.Equal(t, expectedFields, cwMetric.Fields)
 
 			// Check CW measurement
 			assert.Equal(t, len(tc.expectedDims), len(cwMetric.Measurements))
 			for i, dimensions := range tc.expectedDims {
-				cwMeasurement := cwMetric.Measurements[i]
-				assert.Equal(t, namespace, cwMeasurement.Namespace)
-				assert.Equal(t, metricSlice, cwMeasurement.Metrics)
-				assertDimsEqual(t, dimensions, cwMeasurement.Dimensions)
+				expectedMeasurement := CwMeasurement{
+					Namespace:  namespace,
+					Dimensions: dimensions,
+					Metrics:    metricSlice,
+				}
+				assertCwMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[i])
 			}
 		})
 	}
@@ -1799,6 +1812,105 @@ func createMetricTestData() consumerdata.MetricsData {
 	}
 }
 
+func TestDedupDimensions(t *testing.T) {
+	rolledUpDims := [][]string{
+		{"a", OTellibDimensionKey},
+		{"b", OTellibDimensionKey},
+		{"c", OTellibDimensionKey},
+	}
+	testCases := []struct {
+		testName string
+		input    [][]string
+		output   [][]string
+	}{
+		{
+			"Single dimension set",
+			[][]string{{"a"}},
+			[][]string{
+				{"a"},
+				{"a", OTellibDimensionKey},
+				{"b", OTellibDimensionKey},
+				{"c", OTellibDimensionKey},
+			},
+		},
+		{
+			"No duplicates",
+			[][]string{{"a"}, {"b", "c"}},
+			[][]string{
+				{"a"},
+				{"b", "c"},
+				{"a", OTellibDimensionKey},
+				{"b", OTellibDimensionKey},
+				{"c", OTellibDimensionKey}},
+		},
+		{
+			"Contains duplicates",
+			[][]string{{"a"}, {"b", "c"}, {"a"}},
+			[][]string{
+				{"a"},
+				{"b", "c"},
+				{"a", OTellibDimensionKey},
+				{"b", OTellibDimensionKey},
+				{"c", OTellibDimensionKey},
+			},
+		},
+		{
+			"Contains duplicates out of order",
+			[][]string{{"a"}, {"b", "c"}, {"c", "b"}},
+			[][]string{
+				{"a"},
+				{"b", "c"},
+				{"a", OTellibDimensionKey},
+				{"b", OTellibDimensionKey},
+				{"c", OTellibDimensionKey},
+			},
+		},
+		{
+			"Contains duplicates w/ rolledupDims",
+			[][]string{
+				{"a"},
+				{"b", "c"},
+				{"a", OTellibDimensionKey},
+				{"b", OTellibDimensionKey},
+			},
+			[][]string{
+				{"a"},
+				{"b", "c"},
+				{"a", OTellibDimensionKey},
+				{"b", OTellibDimensionKey},
+				{"c", OTellibDimensionKey},
+			},
+		},
+		{
+			"Big test case",
+			[][]string{
+				{"a"},
+				{"a", "b", "c"},
+				{"a", "b"},
+				{"b", "a"},
+				{"a"},
+				{"b", "d"},
+			},
+			[][]string{
+				{"a"},
+				{"a", "b", "c"},
+				{"a", "b"},
+				{"b", "d"},
+				{"a", OTellibDimensionKey},
+				{"b", OTellibDimensionKey},
+				{"c", OTellibDimensionKey},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			deduped := dedupDimensions(tc.input, rolledUpDims)
+			assertDimsEqual(t, tc.output, deduped)
+		})
+	}
+}
+
 func TestNeedsCalculateRate(t *testing.T) {
 	metric := pdata.NewMetric()
 	metric.InitEmpty()
@@ -1908,5 +2020,21 @@ func BenchmarkTranslateCWMetricToEMF(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		TranslateCWMetricToEMF([]*CWMetrics{met}, logger)
+	}
+}
+
+func BenchmarkDedupDimensions(b *testing.B) {
+	input := [][]string{
+		{"label1"},
+		{"label1", "label2"},
+		{"label2", "label1"},
+		{"label2", OTellibDimensionKey},
+	}
+	rolledUpDims := [][]string{
+		{"label1", OTellibDimensionKey},
+		{"label2", OTellibDimensionKey},
+	}
+	for n := 0; n < b.N; n++ {
+		dedupDimensions(input, rolledUpDims)
 	}
 }


### PR DESCRIPTION
**Description:** 
There was an upstream change that included a check to remove duplicated single dimension rollup (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1280). Although this was a really fast check, it only worked for a very specific use case when the dimension set before roll-up is _only_ the labels. This approach for deduping dimension sets is not generalized and fails to work with the dimension setting introduced in #2.

Additionally, we perform dedup checks for user-defined metric declarations:
1. Duplicated dimensions in a dimension set (i.e. `['dim1', 'dim2', 'dim1']` -> `['dim1', 'dim2']`)
2. Duplicated dimension sets (i.e. `[['dim1', 'dim2'], ['dim2', 'dim1']]` -> `[['dim1', 'dim2']]`)

This PR aims to generalize the dedup logic to all exported dimensions. That is, it removes any duplicates from the dimensions set by the user and any overlap with the rolled-up dimensions.

The disadvantage to this is the extra performance hit for performing this dedup logic.

**Testing:**
- Unit tests have been implemented to ensure that the dedup logic is correct.
- I have experimented with multiple ways to perform this dedup logic and benchmarked their performance:

| Method |  # of iterations | Time/op  | Bytes/op  | Allocs/op  |
|:--------|:--------------:|:---------:|:---------:|:-----------:|
|  Append rolled-up dims to dimensions, then perform dedup | 1354779   | 891 ns/op   | 656 B/op  | 13 allocs/op  |
|  **Perform dedup and append at the same time** | 1554196  |   769 ns/op |   416 B/op  |  12 allocs/op |
|  Use map instead of string concatenation to perform duplication checking | 1342286  |   860 ns/op | 1024 B/op   | 10 allocs/op  |