### PR TITLE
Benchmarks

### DIFF
--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -206,11 +206,26 @@ func (emf *emfExporter) Start(ctx context.Context, host component.Host) error {
 }
 
 func generateLogEventFromMetric(metric pdata.Metrics, config *Config) ([]*LogEvent, int, string) {
-	var totalDroppedMetrics int
 	namespace := config.Namespace
-	groupedMetricMap := make(map[string]*GroupedMetric)
-	groupedMetricMap, totalDroppedMetrics = TranslateOtToGroupedMetric(metric, config)
-	return TranslateBatchedMetricToEMF(groupedMetricMap), totalDroppedMetrics, namespace
+	rms := metric.ResourceMetrics()
+	cwMetricLists := []*CWMetrics{}
+	var cwm []*CWMetrics
+	var totalDroppedMetrics int
+
+	for i := 0; i < rms.Len(); i++ {
+		rm := rms.At(i)
+		if rm.IsNil() {
+			continue
+		}
+		cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, config)
+		if len(cwm) > 0 && len(cwm[0].Measurements) > 0 {
+			namespace = cwm[0].Measurements[0].Namespace
+		}
+		// append all datapoint metrics in the request into CWMetric list
+		cwMetricLists = append(cwMetricLists, cwm...)
+	}
+
+	return TranslateCWMetricToEMF(cwMetricLists, config.logger), totalDroppedMetrics, namespace
 }
 
 func wrapErrorIfBadRequest(err *error) error {

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -206,26 +206,11 @@ func (emf *emfExporter) Start(ctx context.Context, host component.Host) error {
 }
 
 func generateLogEventFromMetric(metric pdata.Metrics, config *Config) ([]*LogEvent, int, string) {
-	namespace := config.Namespace
-	rms := metric.ResourceMetrics()
-	cwMetricLists := []*CWMetrics{}
-	var cwm []*CWMetrics
 	var totalDroppedMetrics int
-
-	for i := 0; i < rms.Len(); i++ {
-		rm := rms.At(i)
-		if rm.IsNil() {
-			continue
-		}
-		cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, config)
-		if len(cwm) > 0 && len(cwm[0].Measurements) > 0 {
-			namespace = cwm[0].Measurements[0].Namespace
-		}
-		// append all datapoint metrics in the request into CWMetric list
-		cwMetricLists = append(cwMetricLists, cwm...)
-	}
-
-	return TranslateCWMetricToEMF(cwMetricLists, config.logger), totalDroppedMetrics, namespace
+	namespace := config.Namespace
+	groupedMetricMap := make(map[string]*GroupedMetric)
+	groupedMetricMap, totalDroppedMetrics = TranslateOtToGroupedMetric(metric, config)
+	return TranslateBatchedMetricToEMF(groupedMetricMap), totalDroppedMetrics, namespace
 }
 
 func wrapErrorIfBadRequest(err *error) error {

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -197,7 +197,7 @@ func TranslateOtToGroupedMetric(metric pdata.Metrics, config *Config) (map[strin
 }
 
 
-func getGroupedMetrics(metric *pdata.Metric, namespace string, instrumentationLibName string, groupedMetricMap map[string]*GroupedMetric, config *Config) {
+func getGroupedMetrics(metric *pdata.Metric, namespace string, instrumentationLibName string, groupedMetricMap map[string]*GroupedMetric, config *Config) (groupedMetrics []*GroupedMetric){
 	if metric == nil {
 		return
 	}
@@ -250,13 +250,16 @@ func getGroupedMetrics(metric *pdata.Metric, namespace string, instrumentationLi
 
 		if _, ok := groupedMetricMap[key]; ok {
 			updateGroupedMetric(dp, metric, key, groupedMetricMap)
+			groupedMetrics = append(groupedMetrics, groupedMetricMap[key])
 		} else {
 			groupedMetric := buildGroupedMetric(dp, fields, metric, config.DimensionRollupOption)
 			if groupedMetric != nil {
 				groupedMetricMap[key] = groupedMetric
+				groupedMetrics = append(groupedMetrics,groupedMetric)
 			}
 		}
 	}
+	return
 }
 
 // buildGroupedMetric builds GroupedMetric from Datapoint and pdata.Metric

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -26,7 +26,6 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	// "github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -257,13 +256,13 @@ func assertCWMeasurementEqual(t *testing.T, expected, actual CWMeasurement) {
 	assertDimsEqual(t, expected.Dimensions, actual.Dimensions)
 }
 
+// Asserts whether GroupedMetric Labels and Metrics are equal
 func TestTranslateOtToGroupedMetric(t *testing.T) {
-	metricsMap := make(map[string]MetricInfo)
-	groupedMetricMap := make(map[string]*GroupedMetric)
 	config := &Config{
 		Namespace:             "",
 		DimensionRollupOption: ZeroAndSingleDimensionRollup,
 	}
+	groupedMetricMap := make(map[string]*GroupedMetric)
 	md := createMetricTestData()
 	rm := internaldata.OCToMetrics(md)
 	totalDroppedMetrics := 0
@@ -272,59 +271,62 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 	assert.Equal(t, 0, totalDroppedMetrics)
 	assert.NotNil(t, groupedMetricMap)
 
-	metricsMap = groupedMetricMap["NamespaceOTelLibUndefinedfalseisItAnErrormyServiceNS/myServiceNamespanNametestSpan"].Metrics
-	assert.Equal(t, 4, len(metricsMap))
-	metricsMap = groupedMetricMap["NamespaceOTelLibUndefinedmyServiceNS/myServiceNamespanNametestSpan"].Metrics
-	assert.Equal(t, 1, len(metricsMap))
-
-	var labels []string
-	for i, _ := range groupedMetricMap["NamespaceOTelLibUndefinedmyServiceNS/myServiceNamespanNametestSpan"].Labels {
-		labels = append(labels, i)
+	for k,v:=range groupedMetricMap{
+		if strings.Contains(k, "isItAnError") {
+			assert.Equal(t, 2, len(v.Labels))
+			assert.Equal(t, 4, len(v.Metrics))
+			assert.Equal(t, map[string]string{"isItAnError":"false", "spanName":"testSpan"}, v.Labels)
+		} else {
+			assert.Equal(t, 1, len(v.Labels))
+			assert.Equal(t, 1, len(v.Metrics))
+			assert.Equal(t, map[string]string{"spanName":"testSpan"}, v.Labels)
+		}
 	}
-	sort.Strings(labels)
-	assert.Equal(t, []string{"OTelLib", "spanName"}, labels)
-	
-	labels = nil
-	
-	for i, _ := range groupedMetricMap["NamespaceOTelLibUndefinedmyServiceNS/myServiceNamespanNametestSpan"].Labels {
-		labels = append(labels, i)
-	}
-	sort.Strings(labels)
-	assert.Equal(t, []string{"OTelLib", "spanName"}, labels)
 }
 
-func TestTranslateOtToGroupedMetricWithNameSpace(t *testing.T) {
-	metricsMap := make(map[string]MetricInfo)
+// Asserts whether GroupedMetric Label contains InstrLibName
+func TestTranslateOtToGroupedMetricWithInstrLibrary(t *testing.T) {
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: ZeroAndSingleDimensionRollup,
+		logger:                zap.NewNop(),
+	}
 	groupedMetricMap := make(map[string]*GroupedMetric)
+	md := createMetricTestData()
+	rms := internaldata.OCToMetrics(md)
+	rm := rms.ResourceMetrics().At(0)
+	ilms := rm.InstrumentationLibraryMetrics()
+	ilm := ilms.At(0)
+	ilm.InstrumentationLibrary().InitEmpty()
+	ilm.InstrumentationLibrary().SetName("cloudwatch-lib")
+	groupedMetricMap, totalDroppedMetrics := TranslateOtToGroupedMetric(rms, config)
+	assert.Equal(t, 0, totalDroppedMetrics)
+	for k,v := range groupedMetricMap{
+		if strings.Contains(k, "isItAnError") {
+			assert.Equal(t, "cloudwatch-lib", v.Labels[OTellibDimensionKey])
+			assert.Equal(t, map[string]string{"OTelLib":"cloudwatch-lib", "isItAnError":"false", "spanName":"testSpan"}, v.Labels)
+		} else {
+			assert.Equal(t, "cloudwatch-lib", v.Labels[OTellibDimensionKey])
+			assert.Equal(t, map[string]string{"OTelLib":"cloudwatch-lib", "spanName":"testSpan"}, v.Labels)
+		}
+	}
+}
+
+// Asserts whether GroupedMetric Namespace equals defined NS value
+func TestTranslateOtToGroupedMetricWithNameSpace(t *testing.T) {
 	config := &Config{
 		Namespace:             "",
 		DimensionRollupOption: ZeroAndSingleDimensionRollup,
 	}
+
 	md := consumerdata.MetricsData{
 		Node: &commonpb.Node{
 			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
 		},
 		Resource: &resourcepb.Resource{
 			Labels: map[string]string{
-				conventions.AttributeServiceName: "myServiceName",
-			},
-		},
-		Metrics: []*metricspb.Metric{},
-	}
-	rm := internaldata.OCToMetrics(md)
-	totalDroppedMetrics := 0
-	groupedMetricMap, totalDroppedMetrics = TranslateOtToGroupedMetric(rm, config)
-	
-	assert.Equal(t, 0, totalDroppedMetrics)
-	assert.Equal(t, 0, len(groupedMetricMap))
-	
-	md = consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
-		},
-		Resource: &resourcepb.Resource{
-			Labels: map[string]string{
 				conventions.AttributeServiceNamespace: "myServiceNS",
+				conventions.AttributeServiceName: "myServiceName",
 			},
 		},
 		Metrics: []*metricspb.Metric{
@@ -360,29 +362,103 @@ func TestTranslateOtToGroupedMetricWithNameSpace(t *testing.T) {
 			},
 		},
 	}
-
-	rm = internaldata.OCToMetrics(md)
-	groupedMetricMap, totalDroppedMetrics = TranslateOtToGroupedMetric(rm, config)
-	metricsMap = groupedMetricMap["NamespaceOTelLibUndefinedfalseisItAnErrormyServiceNSspanNametestSpan"].Metrics
-
+	rm := internaldata.OCToMetrics(md)
+	groupedMetricMap := make(map[string]*GroupedMetric)
+	groupedMetricMap, totalDroppedMetrics := TranslateOtToGroupedMetric(rm, config)
 	assert.Equal(t, 0, totalDroppedMetrics)
-	assert.NotNil(t, groupedMetricMap)
-	assert.Equal(t, 1, len(metricsMap))
-	assert.Equal(t, "myServiceNS", groupedMetricMap["NamespaceOTelLibUndefinedfalseisItAnErrormyServiceNSspanNametestSpan"].Namespace)
+
+	for _, v := range groupedMetricMap{
+		assert.Equal(t, "myServiceNS/myServiceName", v.Namespace)
+	}
+}
+
+// Asserts whether GroupedMetric Namespace equals default if undefined 
+func TestTranslateOtToGroupedMetricNoNameSpace(t *testing.T) {
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: ZeroAndSingleDimensionRollup,
+	}
+	md := consumerdata.MetricsData{
+		Metrics: []*metricspb.Metric{
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+							{Value: "false", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	rm := internaldata.OCToMetrics(md)
+	groupedMetricMap := make(map[string]*GroupedMetric)
+	groupedMetricMap, totalDroppedMetrics := TranslateOtToGroupedMetric(rm, config)
+	assert.Equal(t, 0, totalDroppedMetrics)
+
+	for _, v := range groupedMetricMap{
+		assert.Equal(t, "default", v.Namespace)
+	}
 }
 
 func TestGetGroupedMetrics(t *testing.T) {
-	namespace := "nginx"
+	namespace := "nginxFoo"
 	instrumentationLibName := "InstrLibName"
+	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	config := &Config{
 		Namespace:             "",
 		DimensionRollupOption: "",
+	}
+	
+	metricResults := []MetricInfo {
+		MetricInfo {
+			Value: int64(1),
+			Unit: "Count",
+		},
+		MetricInfo {
+			Value: 0.1,
+			Unit: "Count",
+		},
+		MetricInfo {
+			Value: 0,
+			Unit: "Count",
+		},
+		MetricInfo{
+			Value: &CWMetricStats{
+					Min:   0,
+					Max:   10,
+					Count: 18,
+					Sum:   35.0,
+				},
+			Unit: "Seconds",
+		},
 	}
 
 	testCases := []struct {
 		testName string
 		metric   *metricspb.Metric
-		expected map[string]MetricInfo
+		expected map[string]*MetricInfo
 	}{
 		{
 			"Int gauge",
@@ -410,11 +486,8 @@ func TestGetGroupedMetrics(t *testing.T) {
 					},
 				},
 			},
-			map[string]MetricInfo {
-				"foo": MetricInfo{
-					Value: int64(1),
-					Unit: "Count",
-				},
+			map[string]*MetricInfo {
+				"foo": &metricResults[0],
 			},
 		},
 		{
@@ -443,11 +516,8 @@ func TestGetGroupedMetrics(t *testing.T) {
 					},
 				},
 			},
-			map[string]MetricInfo {
-				"foo": MetricInfo{
-					Value: 0.1,
-					Unit: "Count",
-				},
+			map[string]*MetricInfo {
+				"foo": &metricResults[1],
 			},
 		},
 		{
@@ -477,11 +547,8 @@ func TestGetGroupedMetrics(t *testing.T) {
 					},
 				},
 			},
-			map[string]MetricInfo {
-				"foo": MetricInfo{
-					Value: 0,
-					Unit: "Count",
-				},
+			map[string]*MetricInfo {
+				"foo": &metricResults[2],
 			},
 		},
 		{
@@ -511,11 +578,8 @@ func TestGetGroupedMetrics(t *testing.T) {
 					},
 				},
 			},
-			map[string]MetricInfo {
-				"foo": MetricInfo{
-					Value: 0,
-					Unit: "Count",
-				},
+			map[string]*MetricInfo {
+				"foo": &metricResults[2],
 			},
 		},
 		{
@@ -533,40 +597,6 @@ func TestGetGroupedMetrics(t *testing.T) {
 					{
 						LabelValues: []*metricspb.LabelValue{
 							{Value: "value1", HasValue: true},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_DistributionValue{
-									DistributionValue: &metricspb.DistributionValue{
-										Sum:   15.0,
-										Count: 5,
-										BucketOptions: &metricspb.DistributionValue_BucketOptions{
-											Type: &metricspb.DistributionValue_BucketOptions_Explicit_{
-												Explicit: &metricspb.DistributionValue_BucketOptions_Explicit{
-													Bounds: []float64{0, 10},
-												},
-											},
-										},
-										Buckets: []*metricspb.DistributionValue_Bucket{
-											{
-												Count: 0,
-											},
-											{
-												Count: 4,
-											},
-											{
-												Count: 1,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{HasValue: false},
 							{Value: "value2", HasValue: true},
 						},
 						Points: []*metricspb.Point{
@@ -600,16 +630,8 @@ func TestGetGroupedMetrics(t *testing.T) {
 					},
 				},
 			},
-			map[string]MetricInfo {
-				"foo": MetricInfo{
-					Value: &CWMetricStats{
-							Min:   0,
-							Max:   10,
-							Sum:   15.0,
-							Count: 5,
-						},
-					Unit: "Seconds",
-				},
+			map[string]*MetricInfo {
+				"foo": &metricResults[3],
 			},
 		},
 	}
@@ -637,18 +659,16 @@ func TestGetGroupedMetrics(t *testing.T) {
 			metrics := ilms.At(0).Metrics()
 			assert.Equal(t, 1, metrics.Len())
 			metric := metrics.At(0)
-			
-			getGroupedMetrics(&metric, namespace, instrumentationLibName, groupedMetricMap, config)
-			key := "InstrLibNameNamespaceOTelLiblabel1nginxvalue1"
-			
-			assert.Equal(t, len(tc.expected), len(groupedMetricMap[key].Metrics))
 
-			for i, expected := range tc.expected {
-				metrics := groupedMetricMap[key].Metrics
-				assert.Equal(t, len(tc.expected), len(metrics))
-				assert.Equal(t, i, "foo")
-				assert.Equal(t, expected.Value, metrics["foo"].Value)
-				assert.Equal(t, expected.Unit, metrics["foo"].Unit)
+			getGroupedMetrics(&metric, namespace, instrumentationLibName, timestamp, groupedMetricMap, config)
+
+			for _, v := range groupedMetricMap{
+				assert.Equal(t, namespace, v.Namespace)
+				assert.Equal(t, timestamp, v.Timestamp)
+				assert.Equal(t, len(tc.expected), len(v.Metrics))
+				assert.Equal(t, tc.expected, v.Metrics)
+				assert.Equal(t, 2, len(v.Labels))
+				assert.Equal(t, map[string]string{"OTelLib":"InstrLibName", "label1":"value1",}, v.Labels)
 			}
 		})
 	}
@@ -673,7 +693,7 @@ func TestGetGroupedMetrics(t *testing.T) {
 			DimensionRollupOption: "",
 			logger:                zap.New(obs),
 		}
-		getGroupedMetrics(&metric, namespace, instrumentationLibName, groupedMetricMap, obsConfig)
+		getGroupedMetrics(&metric, namespace, instrumentationLibName, timestamp, groupedMetricMap, obsConfig)
 		assert.Equal(t, 0, len(groupedMetricMap))
 
 		// Test output warning logs
@@ -693,15 +713,16 @@ func TestGetGroupedMetrics(t *testing.T) {
 
 	t.Run("Nil metric", func(t *testing.T) {
 		groupedMetricMap := make(map[string]*GroupedMetric)
-		groupedMetrics := getGroupedMetrics(nil, namespace, instrumentationLibName, groupedMetricMap, config)
+		groupedMetrics := getGroupedMetrics(nil, namespace, instrumentationLibName, timestamp, groupedMetricMap, config)
 		assert.Nil(t, groupedMetrics)
 	})
 }
 
 func TestBuildGroupedMetric(t *testing.T) {
-	namespace := "Namespace"
-	instrLibName := "InstrLibName"
-	OTellibDimensionKey := "OTelLib"
+	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
+	instrLibName := "fooLibName"
+	OTellibDimensionKey := "fooOTelLib"
+	namespace := "fooNamespace"
 	metric := pdata.NewMetric()
 	metric.InitEmpty()
 	metric.SetName("foo")
@@ -715,23 +736,25 @@ func TestBuildGroupedMetric(t *testing.T) {
 		})
 		dp.SetValue(int64(-17))
 
-		fields := map[string]interface{}{
-			"Namespace": namespace,
+		labels := map[string]string{
 			OTellibDimensionKey: instrLibName,
 			"label1": "value1",
 		}
 
-		groupedMetric := buildGroupedMetric(dp, fields, &metric, "")
-
+		groupedMetric := buildGroupedMetric(dp, namespace, timestamp, labels, &metric, "")
 		assert.NotNil(t, groupedMetric)
 		assert.Equal(t, 2, len(groupedMetric.Labels))
 		assert.Equal(t, 1, len(groupedMetric.Metrics))
-		expectedMetrics := map[string]MetricInfo{
-			"foo": MetricInfo {int64(-17), ""},
+		metricInfo := MetricInfo {
+			Value: int64(-17),
+			Unit: "",
+		}
+		expectedMetrics := map[string]*MetricInfo{
+			"foo": &metricInfo,
 		}
 		assert.Equal(t, expectedMetrics, groupedMetric.Metrics)
 		expectedLabels := map[string]string{
-			"OTelLib": "InstrLibName",
+			"fooOTelLib": "fooLibName",
 			"label1": "value1",
 		}
 		assert.Equal(t, expectedLabels, groupedMetric.Labels)
@@ -746,23 +769,26 @@ func TestBuildGroupedMetric(t *testing.T) {
 		})
 		dp.SetValue(0.3)
 
-		fields := map[string]interface{}{
-			"Namespace": namespace,
+		labels := map[string]string{
 			OTellibDimensionKey: instrLibName,
 			"label1": "value1",
 		}
 
-		groupedMetric := buildGroupedMetric(dp, fields, &metric, "")
+		groupedMetric := buildGroupedMetric(dp, namespace, timestamp, labels, &metric, "")
 
 		assert.NotNil(t, groupedMetric)
 		assert.Equal(t, 2, len(groupedMetric.Labels))
 		assert.Equal(t, 1, len(groupedMetric.Metrics))
-		expectedMetrics := map[string]MetricInfo{
-			"foo": MetricInfo {0.3, ""},
+		metricInfo := MetricInfo {
+			Value: float64(0.3),
+			Unit: "",
+		}
+		expectedMetrics := map[string]*MetricInfo{
+			"foo": &metricInfo,
 		}
 		assert.Equal(t, expectedMetrics, groupedMetric.Metrics)
 		expectedLabels := map[string]string{
-			"OTelLib": "InstrLibName",
+			"fooOTelLib": "fooLibName",
 			"label1": "value1",
 		}
 		assert.Equal(t, expectedLabels, groupedMetric.Labels)
@@ -779,23 +805,26 @@ func TestBuildGroupedMetric(t *testing.T) {
 		})
 		dp.SetValue(int64(-9))
 
-		fields := map[string]interface{}{
-			"Namespace": namespace,
+		labels := map[string]string{
 			OTellibDimensionKey: instrLibName,
 			"label1": "value1",
 		}
 
-		groupedMetric := buildGroupedMetric(dp, fields, &metric, "")
+		groupedMetric := buildGroupedMetric(dp, namespace, timestamp, labels, &metric, "")
 
 		assert.NotNil(t, groupedMetric)
 		assert.Equal(t, 2, len(groupedMetric.Labels))
 		assert.Equal(t, 1, len(groupedMetric.Metrics))
-		expectedMetrics := map[string]MetricInfo{
-			"foo": MetricInfo {0, ""},
+		metricInfo := MetricInfo {
+			Value: int(0),
+			Unit: "",
+		}
+		expectedMetrics := map[string]*MetricInfo{
+			"foo": &metricInfo,
 		}
 		assert.Equal(t, expectedMetrics, groupedMetric.Metrics)
 		expectedLabels := map[string]string{
-			"OTelLib": "InstrLibName",
+			"fooOTelLib": "fooLibName",
 			"label1": "value1",
 		}
 		assert.Equal(t, expectedLabels, groupedMetric.Labels)
@@ -812,23 +841,26 @@ func TestBuildGroupedMetric(t *testing.T) {
 		})
 		dp.SetValue(0.3)
 
-		fields := map[string]interface{}{
-			"Namespace": namespace,
+		labels := map[string]string{
 			OTellibDimensionKey: instrLibName,
 			"label1": "value1",
 		}
 
-		groupedMetric := buildGroupedMetric(dp, fields, &metric, "")
+		groupedMetric := buildGroupedMetric(dp, namespace, timestamp, labels, &metric, "")
 
 		assert.NotNil(t, groupedMetric)
 		assert.Equal(t, 2, len(groupedMetric.Labels))
 		assert.Equal(t, 1, len(groupedMetric.Metrics))
-		expectedMetrics := map[string]MetricInfo{
-			"foo": MetricInfo {0, ""},
+		metricInfo := MetricInfo {
+			Value: int(0),
+			Unit: "",
+		}
+		expectedMetrics := map[string]*MetricInfo{
+			"foo": &metricInfo,
 		}
 		assert.Equal(t, expectedMetrics, groupedMetric.Metrics)
 		expectedLabels := map[string]string{
-			"OTelLib": "InstrLibName",
+			"fooOTelLib": "fooLibName",
 			"label1": "value1",
 		}
 		assert.Equal(t, expectedLabels, groupedMetric.Labels)
@@ -846,28 +878,31 @@ func TestBuildGroupedMetric(t *testing.T) {
 		dp.SetBucketCounts([]uint64{1, 2, 3})
 		dp.SetExplicitBounds([]float64{1, 2, 3})
 
-		fields := map[string]interface{}{
-			"Namespace": namespace,
+		labels := map[string]string{
 			OTellibDimensionKey: instrLibName,
 			"label1": "value1",
 		}
 
-		groupedMetric := buildGroupedMetric(dp, fields, &metric, "")
+		groupedMetric := buildGroupedMetric(dp, namespace, timestamp, labels, &metric, "")
 
 		assert.NotNil(t, groupedMetric)
 		assert.Equal(t, 2, len(groupedMetric.Labels))
 		assert.Equal(t, 1, len(groupedMetric.Metrics))
-		expectedMetrics := map[string]MetricInfo{
-			"foo": MetricInfo {&CWMetricStats{
+		metricInfo := MetricInfo {
+			Value: &CWMetricStats{
 				Min:   1,
 				Max:   3,
 				Sum:   17.13,
 				Count: 17,
-			}, ""},
+			},
+			Unit: "",
+		}
+		expectedMetrics := map[string]*MetricInfo{
+			"foo": &metricInfo,
 		}
 		assert.Equal(t, expectedMetrics, groupedMetric.Metrics)
 		expectedLabels := map[string]string{
-			"OTelLib": "InstrLibName",
+			"fooOTelLib": "fooLibName",
 			"label1": "value1",
 		}
 		assert.Equal(t, expectedLabels, groupedMetric.Labels)
@@ -878,364 +913,13 @@ func TestBuildGroupedMetric(t *testing.T) {
 		dp := pdata.NewIntHistogramDataPoint()
 		dp.InitEmpty()
 
-		fields := map[string]interface{}{
-			"Namespace": namespace,
+		labels := map[string]string{
 			OTellibDimensionKey: instrLibName,
 			"label1": "value1",
 		}
 
-		groupedMetric := buildGroupedMetric(dp, fields, &metric, "")
+		groupedMetric := buildGroupedMetric(dp, namespace, timestamp, labels, &metric, "")
 		assert.Nil(t, groupedMetric)
-	})
-}
-
-func TestTranslateOtToCWMetricWithInstrLibrary(t *testing.T) {
-	config := &Config{
-		Namespace:             "",
-		DimensionRollupOption: ZeroAndSingleDimensionRollup,
-		logger:                zap.NewNop(),
-	}
-	md := createMetricTestData()
-	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	ilms := rm.InstrumentationLibraryMetrics()
-	ilm := ilms.At(0)
-	ilm.InstrumentationLibrary().InitEmpty()
-	ilm.InstrumentationLibrary().SetName("cloudwatch-lib")
-	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
-	assert.Equal(t, 0, totalDroppedMetrics)
-	assert.NotNil(t, cwm)
-	assert.Equal(t, 5, len(cwm))
-	assert.Equal(t, 1, len(cwm[0].Measurements))
-
-	met := cwm[0]
-
-	assert.Equal(t, met.Fields["spanCounter"], 0)
-
-	expectedMeasurement := CWMeasurement{
-		Namespace: "myServiceNS/myServiceName",
-		Dimensions: [][]string{
-			{OTellibDimensionKey, "isItAnError", "spanName"},
-			{OTellibDimensionKey},
-			{OTellibDimensionKey, "spanName"},
-			{OTellibDimensionKey, "isItAnError"},
-		},
-		Metrics: []map[string]string{
-			{
-				"Name": "spanCounter",
-				"Unit": "Count",
-			},
-		},
-	}
-	assertCWMeasurementEqual(t, expectedMeasurement, met.Measurements[0])
-}
-
-func TestTranslateOtToCWMetricWithoutInstrLibrary(t *testing.T) {
-	config := &Config{
-		Namespace:             "",
-		DimensionRollupOption: ZeroAndSingleDimensionRollup,
-		logger:                zap.NewNop(),
-	}
-	md := createMetricTestData()
-	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
-	assert.Equal(t, 0, totalDroppedMetrics)
-	assert.NotNil(t, cwm)
-	assert.Equal(t, 5, len(cwm))
-	assert.Equal(t, 1, len(cwm[0].Measurements))
-
-	met := cwm[0]
-	assert.NotContains(t, met.Fields, OTellibDimensionKey)
-	assert.Equal(t, met.Fields["spanCounter"], 0)
-
-	expectedMeasurement := CWMeasurement{
-		Namespace: "myServiceNS/myServiceName",
-		Dimensions: [][]string{
-			{"isItAnError", "spanName"},
-			{},
-			{"spanName"},
-			{"isItAnError"},
-		},
-		Metrics: []map[string]string{
-			{
-				"Name": "spanCounter",
-				"Unit": "Count",
-			},
-		},
-	}
-	assertCWMeasurementEqual(t, expectedMeasurement, met.Measurements[0])
-}
-
-func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {
-	config := &Config{
-		Namespace:             "",
-		DimensionRollupOption: ZeroAndSingleDimensionRollup,
-	}
-	md := consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
-		},
-		Resource: &resourcepb.Resource{
-			Labels: map[string]string{
-				conventions.AttributeServiceName: "myServiceName",
-			},
-		},
-		Metrics: []*metricspb.Metric{},
-	}
-	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
-	assert.Equal(t, 0, totalDroppedMetrics)
-	assert.Nil(t, cwm)
-	assert.Equal(t, 0, len(cwm))
-	md = consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
-		},
-		Resource: &resourcepb.Resource{
-			Labels: map[string]string{
-				conventions.AttributeServiceNamespace: "myServiceNS",
-			},
-		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan", HasValue: true},
-							{Value: "false", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanGaugeCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_GAUGE_INT64,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanGaugeDoubleCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanDoubleCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanDoubleCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-		},
-	}
-	rm = internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, config)
-	assert.Equal(t, 0, totalDroppedMetrics)
-	assert.NotNil(t, cwm)
-	assert.Equal(t, 1, len(cwm))
-
-	met := cwm[0]
-	assert.Equal(t, "myServiceNS", met.Measurements[0].Namespace)
-}
-
-func TestTranslateOtToCWMetricWithFiltering(t *testing.T) {
-	md := consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
-		},
-		Resource: &resourcepb.Resource{
-			Labels: map[string]string{
-				conventions.AttributeServiceName:      "myServiceName",
-				conventions.AttributeServiceNamespace: "myServiceNS",
-			},
-		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan", HasValue: true},
-							{Value: "false", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	ilm := rm.InstrumentationLibraryMetrics().At(0)
-	ilm.InstrumentationLibrary().InitEmpty()
-	ilm.InstrumentationLibrary().SetName("cloudwatch-lib")
-
-	testCases := []struct {
-		testName              string
-		metricNameSelectors   []string
-		dimensionRollupOption string
-		expectedDimensions    [][]string
-		numMeasurements       int
-	}{
-		{
-			"has match w/ Zero + Single dim rollup",
-			[]string{"spanCounter"},
-			ZeroAndSingleDimensionRollup,
-			[][]string{
-				{"spanName", "isItAnError"},
-				{"spanName", OTellibDimensionKey},
-				{OTellibDimensionKey, "isItAnError"},
-				{OTellibDimensionKey},
-			},
-			1,
-		},
-		{
-			"has match w/ no dim rollup",
-			[]string{"spanCounter"},
-			"",
-			[][]string{
-				{"spanName", "isItAnError"},
-				{"spanName", OTellibDimensionKey},
-			},
-			1,
-		},
-		{
-			"No match w/ rollup",
-			[]string{"invalid"},
-			ZeroAndSingleDimensionRollup,
-			[][]string{
-				{OTellibDimensionKey, "spanName"},
-				{OTellibDimensionKey, "isItAnError"},
-				{OTellibDimensionKey},
-			},
-			1,
-		},
-		{
-			"No match w/ no rollup",
-			[]string{"invalid"},
-			"",
-			nil,
-			0,
-		},
-	}
-	logger := zap.NewNop()
-
-	for _, tc := range testCases {
-		m := MetricDeclaration{
-			Dimensions:          [][]string{{"isItAnError", "spanName"}, {"spanName", OTellibDimensionKey}},
-			MetricNameSelectors: tc.metricNameSelectors,
-		}
-		config := &Config{
-			Namespace:             "",
-			DimensionRollupOption: tc.dimensionRollupOption,
-			MetricDeclarations:    []*MetricDeclaration{&m},
-		}
-		t.Run(tc.testName, func(t *testing.T) {
-			err := m.Init(logger)
-			assert.Nil(t, err)
-			cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
-			assert.Equal(t, 0, totalDroppedMetrics)
-			assert.Equal(t, 1, len(cwm))
-			assert.NotNil(t, cwm)
-
-			assert.Equal(t, tc.numMeasurements, len(cwm[0].Measurements))
-
-			if tc.numMeasurements > 0 {
-				dimensions := cwm[0].Measurements[0].Dimensions
-				assertDimsEqual(t, tc.expectedDimensions, dimensions)
-			}
-		})
-	}
-
-	t.Run("No instrumentation library name w/ no dim rollup", func(t *testing.T) {
-		rm = internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-		m := MetricDeclaration{
-			Dimensions:          [][]string{{"isItAnError", "spanName"}, {"spanName", OTellibDimensionKey}},
-			MetricNameSelectors: []string{"spanCounter"},
-		}
-		config := &Config{
-			Namespace:             "",
-			DimensionRollupOption: "",
-			MetricDeclarations:    []*MetricDeclaration{&m},
-		}
-		err := m.Init(logger)
-		assert.Nil(t, err)
-		cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
-		assert.Equal(t, 0, totalDroppedMetrics)
-		assert.Equal(t, 1, len(cwm))
-		assert.NotNil(t, cwm)
-
-		assert.Equal(t, 1, len(cwm[0].Measurements))
-
-		// No OTelLib present
-		expectedDims := [][]string{
-			{"spanName", "isItAnError"},
-		}
-		dimensions := cwm[0].Measurements[0].Dimensions
-		assertDimsEqual(t, expectedDims, dimensions)
 	})
 }
 
@@ -1292,827 +976,6 @@ func TestTranslateCWMetricToEMFNoMeasurements(t *testing.T) {
 	}}
 	assert.Equal(t, 1, logs.Len())
 	assert.Equal(t, expectedLogs, logs.AllUntimed())
-}
-
-func TestGetCWMetrics(t *testing.T) {
-	namespace := "Namespace"
-	OTelLib := OTellibDimensionKey
-	instrumentationLibName := "InstrLibName"
-	config := &Config{
-		Namespace:             "",
-		DimensionRollupOption: "",
-	}
-
-	testCases := []struct {
-		testName string
-		metric   *metricspb.Metric
-		expected []*CWMetrics
-	}{
-		{
-			"Int gauge",
-			&metricspb.Metric{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name: "foo",
-					Type: metricspb.MetricDescriptor_GAUGE_INT64,
-					Unit: "Count",
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "label1"},
-						{Key: "label2"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "value1", HasValue: true},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
-							},
-						},
-					},
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{HasValue: false},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 3,
-								},
-							},
-						},
-					},
-				},
-			},
-			[]*CWMetrics{
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label1", "label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Count"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib:  instrumentationLibName,
-						"foo":    int64(1),
-						"label1": "value1",
-						"label2": "value2",
-					},
-				},
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Count"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib:  instrumentationLibName,
-						"foo":    int64(3),
-						"label2": "value2",
-					},
-				},
-			},
-		},
-		{
-			"Double gauge",
-			&metricspb.Metric{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name: "foo",
-					Type: metricspb.MetricDescriptor_GAUGE_DOUBLE,
-					Unit: "Count",
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "label1"},
-						{Key: "label2"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "value1", HasValue: true},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_DoubleValue{
-									DoubleValue: 0.1,
-								},
-							},
-						},
-					},
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{HasValue: false},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_DoubleValue{
-									DoubleValue: 0.3,
-								},
-							},
-						},
-					},
-				},
-			},
-			[]*CWMetrics{
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label1", "label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Count"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib:  instrumentationLibName,
-						"foo":    0.1,
-						"label1": "value1",
-						"label2": "value2",
-					},
-				},
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Count"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib:  instrumentationLibName,
-						"foo":    0.3,
-						"label2": "value2",
-					},
-				},
-			},
-		},
-		{
-			"Int sum",
-			&metricspb.Metric{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name: "foo",
-					Type: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					Unit: "Count",
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "label1"},
-						{Key: "label2"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "value1", HasValue: true},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
-							},
-						},
-					},
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{HasValue: false},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 3,
-								},
-							},
-						},
-					},
-				},
-			},
-			[]*CWMetrics{
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label1", "label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Count"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib:  instrumentationLibName,
-						"foo":    0,
-						"label1": "value1",
-						"label2": "value2",
-					},
-				},
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Count"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib:  instrumentationLibName,
-						"foo":    0,
-						"label2": "value2",
-					},
-				},
-			},
-		},
-		{
-			"Double sum",
-			&metricspb.Metric{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name: "foo",
-					Type: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-					Unit: "Count",
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "label1"},
-						{Key: "label2"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "value1", HasValue: true},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_DoubleValue{
-									DoubleValue: 0.1,
-								},
-							},
-						},
-					},
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{HasValue: false},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_DoubleValue{
-									DoubleValue: 0.3,
-								},
-							},
-						},
-					},
-				},
-			},
-			[]*CWMetrics{
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label1", "label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Count"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib:  instrumentationLibName,
-						"foo":    0,
-						"label1": "value1",
-						"label2": "value2",
-					},
-				},
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Count"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib:  instrumentationLibName,
-						"foo":    0,
-						"label2": "value2",
-					},
-				},
-			},
-		},
-		{
-			"Double histogram",
-			&metricspb.Metric{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name: "foo",
-					Type: metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
-					Unit: "Seconds",
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "label1"},
-						{Key: "label2"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "value1", HasValue: true},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_DistributionValue{
-									DistributionValue: &metricspb.DistributionValue{
-										Sum:   15.0,
-										Count: 5,
-										BucketOptions: &metricspb.DistributionValue_BucketOptions{
-											Type: &metricspb.DistributionValue_BucketOptions_Explicit_{
-												Explicit: &metricspb.DistributionValue_BucketOptions_Explicit{
-													Bounds: []float64{0, 10},
-												},
-											},
-										},
-										Buckets: []*metricspb.DistributionValue_Bucket{
-											{
-												Count: 0,
-											},
-											{
-												Count: 4,
-											},
-											{
-												Count: 1,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{HasValue: false},
-							{Value: "value2", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Value: &metricspb.Point_DistributionValue{
-									DistributionValue: &metricspb.DistributionValue{
-										Sum:   35.0,
-										Count: 18,
-										BucketOptions: &metricspb.DistributionValue_BucketOptions{
-											Type: &metricspb.DistributionValue_BucketOptions_Explicit_{
-												Explicit: &metricspb.DistributionValue_BucketOptions_Explicit{
-													Bounds: []float64{0, 10},
-												},
-											},
-										},
-										Buckets: []*metricspb.DistributionValue_Bucket{
-											{
-												Count: 5,
-											},
-											{
-												Count: 6,
-											},
-											{
-												Count: 7,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			[]*CWMetrics{
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label1", "label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Seconds"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib: instrumentationLibName,
-						"foo": &CWMetricStats{
-							Min:   0,
-							Max:   10,
-							Sum:   15.0,
-							Count: 5,
-						},
-						"label1": "value1",
-						"label2": "value2",
-					},
-				},
-				{
-					Measurements: []CWMeasurement{
-						{
-							Namespace: namespace,
-							Dimensions: [][]string{
-								{"label2", OTelLib},
-							},
-							Metrics: []map[string]string{
-								{"Name": "foo", "Unit": "Seconds"},
-							},
-						},
-					},
-					Fields: map[string]interface{}{
-						OTelLib: instrumentationLibName,
-						"foo": &CWMetricStats{
-							Min:   0,
-							Max:   10,
-							Sum:   35.0,
-							Count: 18,
-						},
-						"label2": "value2",
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			oc := consumerdata.MetricsData{
-				Node: &commonpb.Node{},
-				Resource: &resourcepb.Resource{
-					Labels: map[string]string{
-						conventions.AttributeServiceName:      "myServiceName",
-						conventions.AttributeServiceNamespace: "myServiceNS",
-					},
-				},
-				Metrics: []*metricspb.Metric{tc.metric},
-			}
-
-			// Retrieve *pdata.Metric
-			rms := internaldata.OCToMetrics(oc).ResourceMetrics()
-			assert.Equal(t, 1, rms.Len())
-			ilms := rms.At(0).InstrumentationLibraryMetrics()
-			assert.Equal(t, 1, ilms.Len())
-			metrics := ilms.At(0).Metrics()
-			assert.Equal(t, 1, metrics.Len())
-			metric := metrics.At(0)
-
-			cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, config)
-			assert.Equal(t, len(tc.expected), len(cwMetrics))
-
-			for i, expected := range tc.expected {
-				cwMetric := cwMetrics[i]
-				assert.Equal(t, len(expected.Measurements), len(cwMetric.Measurements))
-				for i, expectedMeasurement := range expected.Measurements {
-					assertCWMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[i])
-				}
-				assert.Equal(t, len(expected.Fields), len(cwMetric.Fields))
-				assert.Equal(t, expected.Fields, cwMetric.Fields)
-			}
-		})
-	}
-
-	t.Run("Unhandled metric type", func(t *testing.T) {
-		metric := pdata.NewMetric()
-		metric.InitEmpty()
-		metric.SetName("foo")
-		metric.SetUnit("Count")
-		metric.SetDataType(pdata.MetricDataTypeIntHistogram)
-
-		obs, logs := observer.New(zap.WarnLevel)
-		obsConfig := &Config{
-			DimensionRollupOption: "",
-			logger:                zap.New(obs),
-		}
-
-		cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, obsConfig)
-		assert.Nil(t, cwMetrics)
-
-		// Test output warning logs
-		expectedLogs := []observer.LoggedEntry{
-			{
-				Entry: zapcore.Entry{Level: zap.WarnLevel, Message: "Unhandled metric data type."},
-				Context: []zapcore.Field{
-					zap.String("DataType", "IntHistogram"),
-					zap.String("Name", "foo"),
-					zap.String("Unit", "Count"),
-				},
-			},
-		}
-		assert.Equal(t, 1, logs.Len())
-		assert.Equal(t, expectedLogs, logs.AllUntimed())
-	})
-
-	t.Run("Nil metric", func(t *testing.T) {
-		cwMetrics := getCWMetrics(nil, namespace, instrumentationLibName, config)
-		assert.Nil(t, cwMetrics)
-	})
-}
-
-func TestBuildCWMetric(t *testing.T) {
-	namespace := "Namespace"
-	instrLibName := "InstrLibName"
-	OTelLib := OTellibDimensionKey
-	config := &Config{
-		Namespace:             "",
-		DimensionRollupOption: "",
-	}
-	metricSlice := []map[string]string{
-		{
-			"Name": "foo",
-			"Unit": "",
-		},
-	}
-
-	// Test data types
-	metric := pdata.NewMetric()
-	metric.InitEmpty()
-	metric.SetName("foo")
-
-	t.Run("Int gauge", func(t *testing.T) {
-		metric.SetDataType(pdata.MetricDataTypeIntGauge)
-		dp := pdata.NewIntDataPoint()
-		dp.InitEmpty()
-		dp.LabelsMap().InitFromMap(map[string]string{
-			"label1": "value1",
-		})
-		dp.SetValue(int64(-17))
-
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
-
-		assert.NotNil(t, cwMetric)
-		assert.Equal(t, 1, len(cwMetric.Measurements))
-		expectedMeasurement := CWMeasurement{
-			Namespace:  namespace,
-			Dimensions: [][]string{{"label1", OTelLib}},
-			Metrics:    metricSlice,
-		}
-		assertCWMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
-		expectedFields := map[string]interface{}{
-			OTelLib:  instrLibName,
-			"foo":    int64(-17),
-			"label1": "value1",
-		}
-		assert.Equal(t, expectedFields, cwMetric.Fields)
-	})
-
-	t.Run("Double gauge", func(t *testing.T) {
-		metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
-		dp := pdata.NewDoubleDataPoint()
-		dp.InitEmpty()
-		dp.LabelsMap().InitFromMap(map[string]string{
-			"label1": "value1",
-		})
-		dp.SetValue(0.3)
-
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
-
-		assert.NotNil(t, cwMetric)
-		assert.Equal(t, 1, len(cwMetric.Measurements))
-		expectedMeasurement := CWMeasurement{
-			Namespace:  namespace,
-			Dimensions: [][]string{{"label1", OTelLib}},
-			Metrics:    metricSlice,
-		}
-		assertCWMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
-		expectedFields := map[string]interface{}{
-			OTelLib:  instrLibName,
-			"foo":    0.3,
-			"label1": "value1",
-		}
-		assert.Equal(t, expectedFields, cwMetric.Fields)
-	})
-
-	t.Run("Int sum", func(t *testing.T) {
-		metric.SetDataType(pdata.MetricDataTypeIntSum)
-		metric.IntSum().InitEmpty()
-		metric.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
-		dp := pdata.NewIntDataPoint()
-		dp.InitEmpty()
-		dp.LabelsMap().InitFromMap(map[string]string{
-			"label1": "value1",
-		})
-		dp.SetValue(int64(-17))
-
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
-
-		assert.NotNil(t, cwMetric)
-		assert.Equal(t, 1, len(cwMetric.Measurements))
-		expectedMeasurement := CWMeasurement{
-			Namespace:  namespace,
-			Dimensions: [][]string{{"label1", OTelLib}},
-			Metrics:    metricSlice,
-		}
-		assertCWMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
-		expectedFields := map[string]interface{}{
-			OTelLib:  instrLibName,
-			"foo":    0,
-			"label1": "value1",
-		}
-		assert.Equal(t, expectedFields, cwMetric.Fields)
-	})
-
-	t.Run("Double sum", func(t *testing.T) {
-		metric.SetDataType(pdata.MetricDataTypeDoubleSum)
-		metric.DoubleSum().InitEmpty()
-		metric.DoubleSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
-		dp := pdata.NewDoubleDataPoint()
-		dp.InitEmpty()
-		dp.LabelsMap().InitFromMap(map[string]string{
-			"label1": "value1",
-		})
-		dp.SetValue(0.3)
-
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
-
-		assert.NotNil(t, cwMetric)
-		assert.Equal(t, 1, len(cwMetric.Measurements))
-		expectedMeasurement := CWMeasurement{
-			Namespace:  namespace,
-			Dimensions: [][]string{{"label1", OTelLib}},
-			Metrics:    metricSlice,
-		}
-		assertCWMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
-		expectedFields := map[string]interface{}{
-			OTelLib:  instrLibName,
-			"foo":    0,
-			"label1": "value1",
-		}
-		assert.Equal(t, expectedFields, cwMetric.Fields)
-	})
-
-	t.Run("Double histogram", func(t *testing.T) {
-		metric.SetDataType(pdata.MetricDataTypeDoubleHistogram)
-		dp := pdata.NewDoubleHistogramDataPoint()
-		dp.InitEmpty()
-		dp.LabelsMap().InitFromMap(map[string]string{
-			"label1": "value1",
-		})
-		dp.SetCount(uint64(17))
-		dp.SetSum(17.13)
-		dp.SetBucketCounts([]uint64{1, 2, 3})
-		dp.SetExplicitBounds([]float64{1, 2, 3})
-
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
-
-		assert.NotNil(t, cwMetric)
-		assert.Equal(t, 1, len(cwMetric.Measurements))
-		expectedMeasurement := CWMeasurement{
-			Namespace:  namespace,
-			Dimensions: [][]string{{"label1", OTelLib}},
-			Metrics:    metricSlice,
-		}
-		assertCWMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
-		expectedFields := map[string]interface{}{
-			OTelLib: instrLibName,
-			"foo": &CWMetricStats{
-				Min:   1,
-				Max:   3,
-				Sum:   17.13,
-				Count: 17,
-			},
-			"label1": "value1",
-		}
-		assert.Equal(t, expectedFields, cwMetric.Fields)
-	})
-
-	t.Run("Invalid datapoint type", func(t *testing.T) {
-		metric.SetDataType(pdata.MetricDataTypeIntGauge)
-		dp := pdata.NewIntHistogramDataPoint()
-		dp.InitEmpty()
-
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
-		assert.Nil(t, cwMetric)
-	})
-
-	// Test rollup options and labels
-	testCases := []struct {
-		testName              string
-		labels                map[string]string
-		dimensionRollupOption string
-		expectedDims          [][]string
-	}{
-		{
-			"Single label w/ no rollup",
-			map[string]string{"a": "foo"},
-			"",
-			[][]string{
-				{"a", OTelLib},
-			},
-		},
-		{
-			"Single label w/ single rollup",
-			map[string]string{"a": "foo"},
-			SingleDimensionRollupOnly,
-			[][]string{
-				{"a", OTelLib},
-			},
-		},
-		{
-			"Single label w/ zero + single rollup",
-			map[string]string{"a": "foo"},
-			ZeroAndSingleDimensionRollup,
-			[][]string{
-				{"a", OTelLib},
-				{OTelLib},
-			},
-		},
-		{
-			"Multiple label w/ no rollup",
-			map[string]string{
-				"a": "foo",
-				"b": "bar",
-				"c": "car",
-			},
-			"",
-			[][]string{
-				{"a", "b", "c", OTelLib},
-			},
-		},
-		{
-			"Multiple label w/ rollup",
-			map[string]string{
-				"a": "foo",
-				"b": "bar",
-				"c": "car",
-			},
-			ZeroAndSingleDimensionRollup,
-			[][]string{
-				{"a", "b", "c", OTelLib},
-				{OTelLib, "a"},
-				{OTelLib, "b"},
-				{OTelLib, "c"},
-				{OTelLib},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			dp := pdata.NewIntDataPoint()
-			dp.InitEmpty()
-			dp.LabelsMap().InitFromMap(tc.labels)
-			dp.SetValue(int64(-17))
-			config = &Config{
-				Namespace:             namespace,
-				DimensionRollupOption: tc.dimensionRollupOption,
-			}
-
-			expectedFields := map[string]interface{}{
-				OTellibDimensionKey: OTelLib,
-				"foo":               int64(-17),
-			}
-			for k, v := range tc.labels {
-				expectedFields[k] = v
-			}
-			expectedMeasurement := CWMeasurement{
-				Namespace:  namespace,
-				Dimensions: tc.expectedDims,
-				Metrics:    metricSlice,
-			}
-
-			cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, OTelLib, config)
-
-			// Check fields
-			assert.Equal(t, expectedFields, cwMetric.Fields)
-
-			// Check CW measurement
-			assert.Equal(t, 1, len(cwMetric.Measurements))
-			assertCWMeasurementEqual(t, expectedMeasurement, cwMetric.Measurements[0])
-		})
-	}
 }
 
 func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
@@ -2451,26 +1314,28 @@ func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
 }
 
 func TestCalculateRate(t *testing.T) {
-	prevValue := int64(0)
-	curValue := int64(10)
-	fields := make(map[string]interface{})
-	fields[OTellibDimensionKey] = "cloudwatch-otel"
-	fields["spanName"] = "test"
-	fields["spanCounter"] = prevValue
-	fields["type"] = "Int64"
+	metricName := "newMetric"
+	labels := make(map[string]string)
+	labels[OTellibDimensionKey] = "cloudwatch-otel"
+	labels["spanName"] = "test"
+	labels["spanCounter"] = "foo"
+	labels["type"] = "Int64"
 	prevTime := time.Now().UnixNano() / int64(time.Millisecond)
 	curTime := time.Unix(0, prevTime*int64(time.Millisecond)).Add(time.Second*10).UnixNano() / int64(time.Millisecond)
-	rate := calculateRate(fields, prevValue, prevTime)
+
+	prevValue := int64(0)
+	curValue := int64(10)
+	rate := calculateRate(labels, metricName, prevValue, prevTime)
 	assert.Equal(t, 0, rate)
-	rate = calculateRate(fields, curValue, curTime)
+	rate = calculateRate(labels, metricName, curValue, curTime)
 	assert.Equal(t, int64(1), rate)
 
 	prevDoubleValue := 0.0
 	curDoubleValue := 5.0
-	fields["type"] = "Float64"
-	rate = calculateRate(fields, prevDoubleValue, prevTime)
+	labels["type"] = "Float64"
+	rate = calculateRate(labels, metricName, prevDoubleValue, prevTime)
 	assert.Equal(t, 0, rate)
-	rate = calculateRate(fields, curDoubleValue, curTime)
+	rate = calculateRate(labels, metricName, curDoubleValue, curTime)
 	assert.Equal(t, 0.5, rate)
 }
 

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -1565,3 +1565,29 @@ func BenchmarkDimensionRollup(b *testing.B) {
 		dimensionRollup(ZeroAndSingleDimensionRollup, dimensions, "cloudwatch-otel")
 	}
 }
+
+func BenchmarkGetGroupedMetricKey(b *testing.B) {
+	namespace := "testNamespace"
+	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
+	labels := map[string]string {
+		"OTelLib": "cloudwatch-lib",
+		"isItAnError": "false",
+		"spanName": "testSpan",
+	}
+	for n := 0; n < b.N; n++ {
+		getGroupedMetricKey(namespace, timestamp, labels)
+	}
+}
+
+func BenchmarkGetHashedKey(b *testing.B) {
+	namespace := "testNamespace"
+	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
+	labels := map[string]string {
+		"OTelLib": "cloudwatch-lib",
+		"isItAnError": "false",
+		"spanName": "testSpan",
+	}
+	for n := 0; n < b.N; n++ {
+		getHashedKey(namespace, timestamp, labels)
+	}
+}

--- a/exporter/awsemfexporter/pusher_test.go
+++ b/exporter/awsemfexporter/pusher_test.go
@@ -79,7 +79,7 @@ func TestLogEventBatch_sortLogEvents(t *testing.T) {
 		logEvent := NewLogEvent(
 			int64(timestamp),
 			fmt.Sprintf("message%v", timestamp))
-		fmt.Printf("logEvents[%d].Timetsmap=%d.\n", i, timestamp)
+		fmt.Printf("logEvents[%d].Timestamp=%d.\n", i, timestamp)
 		logEventBatch.PutLogEventsInput.LogEvents = append(logEventBatch.PutLogEventsInput.LogEvents, logEvent.InputLogEvent)
 	}
 


### PR DESCRIPTION
To compare performance between long string key vs hashed key used for populating map of GroupedMetrics

Here were the results observed:

| Benchmark Name | # of ops | Speed |
| ------------- | ------------- | ------------- |
| BenchmarkGetGroupedMetricKey | 14011382 | 854 ns/op  |
| BenchmarkGetHashedKey | 990871  | 1225 ns/op  |